### PR TITLE
Fix consumer group name and add regression test

### DIFF
--- a/core/src/libs/queue-manager.ts
+++ b/core/src/libs/queue-manager.ts
@@ -107,7 +107,7 @@ export class QueueManager<T = unknown> implements QueueManagerInterface<T> {
       await this.streamdb.xgroup(
         'CREATE',
         `${queueName}-stream`,
-        '*', // keep an eye on this as the consumer is always worker
+        'workers', // keep an eye on this as the consumer is always worker
         '$',
         'MKSTREAM',
       );

--- a/core/tests/queue_manager.test.ts
+++ b/core/tests/queue_manager.test.ts
@@ -1,0 +1,85 @@
+import { assertEquals } from 'jsr:@std/assert@1/equals';
+import type { RedisConnection } from '../src/types/index.ts';
+import { QueueManager } from '../src/libs/queue-manager.ts';
+
+Deno.test('registerJob creates workers consumer group', async () => {
+  const xgroupCalls: unknown[][] = [];
+
+  const createRedisMock = (dbIndex = 0): RedisConnection => {
+    const redisMock = {
+      options: { db: dbIndex },
+      duplicate: ({ db }: { db: number }) => createRedisMock(db),
+      async xgroup(...args: unknown[]) {
+        xgroupCalls.push(args);
+      },
+      async set() {
+        return 'OK';
+      },
+      async get() {
+        return null;
+      },
+      async del() {
+        return 0;
+      },
+      async scan() {
+        return ['0', []] as [string, string[]];
+      },
+      async watch() {
+        return 'OK';
+      },
+      async unwatch() {
+        return 'OK';
+      },
+      multi() {
+        return {
+          async exec() {
+            return [];
+          },
+        };
+      },
+      async xadd() {
+        return '0-0';
+      },
+      async xtrim() {
+        return 'OK';
+      },
+      async xreadgroup() {
+        return [];
+      },
+    } as unknown as RedisConnection;
+
+    return redisMock;
+  };
+
+  const redis = createRedisMock(0);
+
+  Reflect.set(
+    QueueManager as unknown as Record<string, unknown>,
+    'instance',
+    undefined,
+  );
+
+  const manager = QueueManager.init({
+    db: redis,
+    ctx: {},
+    concurrency: 1,
+    options: { maxJobsPerStatus: 200 },
+  });
+
+  manager.registerJob({
+    name: 'test-job',
+    queue: 'test-queue',
+    handler: async () => {},
+  });
+
+  await Promise.resolve();
+
+  assertEquals(xgroupCalls.length, 1);
+  assertEquals(xgroupCalls[0], [
+    'CREATE',
+    'test-queue-stream',
+    'workers',
+    '$',
+    'MKSTREAM',
+  ]);
+});


### PR DESCRIPTION
## Summary
- update the queue manager to create the `workers` consumer group when initializing streams
- add a regression test that verifies registering a job creates the `workers` consumer group with MKSTREAM

## Testing
- `deno test --config deno.json` *(fails: command not found: deno)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912d32c5df4832e802fe88761c7cea8)