### PR TITLE
feat: add hound.use() middleware and timeoutMs handler option

### DIFF
--- a/core/libs/hound/mod.ts
+++ b/core/libs/hound/mod.ts
@@ -19,6 +19,7 @@ import type {
   EmitFunction,
   EmitOptions,
   HandlerOptions,
+  JobContext,
   JobData,
   JobDefinition,
   JobHandler,
@@ -26,6 +27,7 @@ import type {
   JobSocketContext,
   Message,
   MessageContext,
+  MiddlewareFn,
   ProcessableMessage,
   RedisConnection,
 } from '../../types/index.ts';
@@ -48,6 +50,7 @@ export type {
   JobDefinition,
   JobHandler,
   HoundOptions,
+  MiddlewareFn,
 } from '../../types/index.ts';
 
 /** Symbol for internal subscription. Not part of public API. */
@@ -72,9 +75,12 @@ export class Hound<
   // emits within the same millisecond are enqueued in call order, not async-resolution order.
   #emitSeq = 0;
 
+  #middleware: MiddlewareFn<TApp>[] = [];
+
   private handlers: Map<string, JobHandler<TApp, any>> = new Map();
   private handlerDebounce: Map<string, DebounceManager> = new Map();
   private handlerSemaphores: Map<string, { limit: number; active: number }> = new Map();
+  private handlerTimeouts: Map<string, number> = new Map();
   private pendingCronJobs: Map<
     string,
     {
@@ -204,6 +210,10 @@ export class Hound<
       this.handlerSemaphores.set(handlerKey, { limit: opts.concurrency, active: 0 });
     }
 
+    if (opts?.timeoutMs !== undefined && opts.timeoutMs > 0) {
+      this.handlerTimeouts.set(handlerKey, opts.timeoutMs);
+    }
+
     if (opts?.debounce !== undefined) {
       const debounceSeconds = Math.ceil(opts.debounce / 1000);
       this.handlerDebounce.set(handlerKey, new DebounceManager(debounceSeconds, undefined));
@@ -218,6 +228,23 @@ export class Hound<
       });
     }
 
+    return this;
+  }
+
+  /**
+   * Register a global middleware that wraps every job handler execution.
+   * Middleware runs in registration order; call `next()` to continue the chain.
+   * Throwing (or not calling `next()`) short-circuits the handler.
+   *
+   * @example
+   * hound.use(async (ctx, next) => {
+   *   const start = Date.now();
+   *   try { await next(); }
+   *   finally { metrics.record(ctx.name, Date.now() - start); }
+   * });
+   */
+  use(fn: MiddlewareFn<TApp>): this {
+    this.#middleware.push(fn);
     return this;
   }
 
@@ -893,7 +920,8 @@ ${'─'.repeat(40)}
         }
       }
 
-      await handler(handlerCtx);
+      const timeoutMs = this.handlerTimeouts.get(`${queueName}:${jobEntry.state.name}`);
+      await this.#runHandler(handler, handlerCtx, timeoutMs);
 
       const completedData = {
         ...processingData,
@@ -984,6 +1012,43 @@ ${'─'.repeat(40)}
 
     await this.#setJobState(stateKey, JSON.stringify(nextJobData));
     await this.queueStore.enqueue(queueName, jobId, score);
+  }
+
+  //  Middleware execution
+
+  async #runHandler(
+    handler: JobHandler<TApp, any>,
+    ctx: JobContext<TApp, any>,
+    timeoutMs?: number,
+  ): Promise<void> {
+    const run = (): Promise<void> => {
+      if (this.#middleware.length === 0) return handler(ctx);
+      let index = -1;
+      const middleware = this.#middleware;
+      const dispatch = async (i: number): Promise<void> => {
+        if (i <= index) throw new Error('[hound] next() called multiple times');
+        index = i;
+        if (i === middleware.length) return handler(ctx);
+        return middleware[i](ctx, () => dispatch(i + 1));
+      };
+      return dispatch(0);
+    };
+
+    if (!timeoutMs) return run();
+
+    let timer!: ReturnType<typeof setTimeout>;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error(`[hound] Job "${ctx.name}" timed out after ${timeoutMs}ms`)),
+        timeoutMs,
+      );
+    });
+
+    try {
+      return await Promise.race([run(), timeout]);
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   // ─── Socket context (stub) ────────────────────────────────────────────────

--- a/core/mod.ts
+++ b/core/mod.ts
@@ -68,6 +68,7 @@ export type {
   HandlerOptions,
   // Hound options
   HoundOptions,
+  MiddlewareFn,
   JobContext,
   JobDefinition,
   JobError,

--- a/core/tests/middleware.test.ts
+++ b/core/tests/middleware.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Middleware tests — hound.use() integration, run against InMemoryStorage.
+ */
+import { assertEquals, assertRejects } from 'jsr:@std/assert';
+import { withHound } from './helpers.ts';
+
+Deno.test('middleware runs before and after the handler', () =>
+  withHound(async (h) => {
+    const order: string[] = [];
+
+    h.use(async (ctx, next) => {
+      order.push('before');
+      await next();
+      order.push('after');
+    });
+
+    h.on('mw.order', async () => { order.push('handler'); });
+
+    await h.start();
+    await h.emitAndWait('mw.order', {}, { timeoutMs: 3000 });
+
+    assertEquals(order, ['before', 'handler', 'after']);
+  }));
+
+Deno.test('multiple middleware run in registration order', () =>
+  withHound(async (h) => {
+    const order: string[] = [];
+
+    h.use(async (_ctx, next) => { order.push('mw1-before'); await next(); order.push('mw1-after'); });
+    h.use(async (_ctx, next) => { order.push('mw2-before'); await next(); order.push('mw2-after'); });
+
+    h.on('mw.multi', async () => { order.push('handler'); });
+
+    await h.start();
+    await h.emitAndWait('mw.multi', {}, { timeoutMs: 3000 });
+
+    assertEquals(order, ['mw1-before', 'mw2-before', 'handler', 'mw2-after', 'mw1-after']);
+  }));
+
+Deno.test('middleware receives correct ctx fields', () =>
+  withHound(async (h) => {
+    let seenName: string | undefined;
+    let seenQueue: string | undefined;
+
+    h.use(async (ctx, next) => {
+      seenName = ctx.name;
+      seenQueue = ctx.queue;
+      await next();
+    });
+
+    h.on('mw.ctx', async () => {}, { queue: 'myqueue' });
+
+    await h.start();
+    await h.emitAndWait('mw.ctx', {}, { timeoutMs: 3000 });
+
+    assertEquals(seenName, 'mw.ctx');
+    assertEquals(seenQueue, 'myqueue');
+  }));
+
+Deno.test('middleware that throws fails the job', () =>
+  withHound(async (h) => {
+    h.use(async (_ctx, _next) => {
+      throw new Error('middleware boom');
+    });
+
+    h.on('mw.throw', async () => {});
+
+    await h.start();
+
+    await assertRejects(
+      () => h.emitAndWait('mw.throw', {}, { timeoutMs: 3000 }),
+      Error,
+    );
+  }));
+
+Deno.test('middleware that skips next() prevents handler from running', () =>
+  withHound(async (h) => {
+    let handlerRan = false;
+
+    h.use(async (_ctx, _next) => {
+      // intentionally does not call next()
+    });
+
+    h.on('mw.skip', async () => { handlerRan = true; });
+
+    await h.start();
+    // job completes (middleware resolved without error) but handler never ran
+    await h.emitAndWait('mw.skip', {}, { timeoutMs: 3000 });
+
+    assertEquals(handlerRan, false);
+  }));
+
+Deno.test('use() is chainable', () =>
+  withHound(async (h) => {
+    let count = 0;
+
+    h
+      .use(async (_ctx, next) => { count++; await next(); })
+      .use(async (_ctx, next) => { count++; await next(); });
+
+    h.on('mw.chain', async () => {});
+
+    await h.start();
+    await h.emitAndWait('mw.chain', {}, { timeoutMs: 3000 });
+
+    assertEquals(count, 2);
+  }));

--- a/core/tests/timeout.test.ts
+++ b/core/tests/timeout.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Per-handler timeout tests — run against InMemoryStorage.
+ */
+import { assert, assertEquals, assertRejects } from 'jsr:@std/assert';
+import { withHound } from './helpers.ts';
+
+Deno.test('job completes normally when handler finishes before timeout', () =>
+  withHound(async (h) => {
+    let ran = false;
+    h.on('timeout.fast', async () => { ran = true; }, { timeoutMs: 500 });
+    await h.start();
+    await h.emitAndWait('timeout.fast', {}, { timeoutMs: 3000 });
+    assertEquals(ran, true);
+  }));
+
+Deno.test('job fails when handler exceeds timeoutMs', () =>
+  withHound(async (h) => {
+    // Use a manually-resolved Promise instead of setTimeout so there's no
+    // abandoned timer after Promise.race rejects — resolve it after assertRejects.
+    let unblock!: () => void;
+    const block = new Promise<void>((r) => { unblock = r; });
+
+    h.on('timeout.slow', () => block, { timeoutMs: 50 });
+
+    await h.start();
+    await assertRejects(
+      () => h.emitAndWait('timeout.slow', {}, { timeoutMs: 3000 }),
+      Error,
+    );
+    unblock();
+  }));
+
+Deno.test('timeout error message includes job name and duration', () =>
+  withHound(async (h) => {
+    let unblock!: () => void;
+    const block = new Promise<void>((r) => { unblock = r; });
+
+    h.on('timeout.msg', () => block, { timeoutMs: 50 });
+
+    await h.start();
+    let message = '';
+    try {
+      await h.emitAndWait('timeout.msg', {}, { timeoutMs: 3000 });
+    } catch (e: any) {
+      message = e.message;
+    }
+    assert(message.includes('timeout.msg'), `expected job name in error: ${message}`);
+    assert(message.includes('50ms'), `expected duration in error: ${message}`);
+    unblock();
+  }));
+
+Deno.test('timeout applies to the full middleware + handler chain', () =>
+  withHound(async (h) => {
+    let unblock!: () => void;
+    const block = new Promise<void>((r) => { unblock = r; });
+
+    h.use(async (_ctx, next) => {
+      await block;
+      await next();
+    });
+
+    h.on('timeout.mw', async () => {}, { timeoutMs: 50 });
+
+    await h.start();
+    await assertRejects(
+      () => h.emitAndWait('timeout.mw', {}, { timeoutMs: 3000 }),
+      Error,
+    );
+    unblock();
+  }));
+
+Deno.test('no timeout when timeoutMs is not set', () =>
+  withHound(async (h) => {
+    let ran = false;
+    h.on('timeout.none', async () => {
+      await new Promise((r) => setTimeout(r, 100));
+      ran = true;
+    });
+
+    await h.start();
+    await h.emitAndWait('timeout.none', {}, { timeoutMs: 3000 });
+    assertEquals(ran, true);
+  }));

--- a/core/types/index.ts
+++ b/core/types/index.ts
@@ -112,6 +112,21 @@ export type JobHandler<
   TData = unknown,
 > = (ctx: JobContext<TApp, TData>) => Promise<void>;
 
+/**
+ * Middleware function — wraps every job handler execution.
+ * Call `next()` to continue the chain; throwing skips it and fails the job.
+ *
+ * @example
+ * hound.use(async (ctx, next) => {
+ *   const start = Date.now();
+ *   await next();
+ *   metrics.record(ctx.name, Date.now() - start);
+ * });
+ */
+export type MiddlewareFn<
+  TApp extends Record<string, unknown> = Record<string, unknown>,
+> = (ctx: JobContext<TApp, unknown>, next: () => Promise<void>) => Promise<void>;
+
 /** Options when registering a handler with `hound.on()`. */
 export interface HandlerOptions {
   /** Target queue. Defaults to 'default'. */
@@ -130,6 +145,15 @@ export interface HandlerOptions {
    * Example: { concurrency: 2 } — at most 2 instances run in parallel.
    */
   concurrency?: number;
+  /**
+   * Per-handler execution timeout in ms. If the handler (including middleware) does not
+   * resolve within this window, the job fails with a timeout error and the normal retry
+   * policy applies. Useful for handlers that call external APIs or do I/O with no built-in timeout.
+   *
+   * @example
+   * hound.on('payment.charge', handler, { timeoutMs: 8_000 });
+   */
+  timeoutMs?: number;
 }
 
 /**

--- a/deno.lock
+++ b/deno.lock
@@ -4,6 +4,7 @@
     "jsr:@deno/esbuild-plugin@^1.2.1": "1.2.1",
     "jsr:@deno/loader@~0.3.10": "0.3.14",
     "jsr:@hushkey/howl@0.4": "0.4.0",
+    "jsr:@std/assert@*": "1.0.19",
     "jsr:@std/bytes@^1.0.6": "1.0.6",
     "jsr:@std/encoding@1": "1.0.10",
     "jsr:@std/encoding@^1.0.10": "1.0.10",
@@ -73,6 +74,12 @@
         "npm:preact-render-to-string",
         "npm:tailwindcss@4",
         "npm:zod"
+      ]
+    },
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
       ]
     },
     "@std/bytes@1.0.6": {


### PR DESCRIPTION
# `hound.use()` — global middleware

Register middleware that wraps every job handler execution. Runs in
registration order; `next()` continues the chain. Throwing or skipping
`next()` short-circuits the handler and fails the job.

```ts
hound.use(async (ctx, next) => {
  const span = tracer.startSpan(ctx.name);
  try {
    await next();
    span.setStatus({ code: SpanStatusCode.OK });
  } catch (err) {
    span.recordException(err);
    throw err;
  } finally {
    span.end();
  }
});
