### PR TITLE
[HND-00014] 🐪 feat: add hound.emitBatch() for single-pipeline batch emission

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,13 @@ const jobId = hound.emit("property.sync", { propertyId: 1 });
 
 // Awaitable — resolves when state key + queue entry are both written
 const jobId = await hound.emitAsync("property.sync", { propertyId: 1 });
+
+// Batch — all jobs in a single Redis pipeline (one round trip)
+const jobIds = await hound.emitBatch([
+  { event: "email.send", data: { to: "alice@example.com" } },
+  { event: "email.send", data: { to: "bob@example.com" } },
+  { event: "analytics.track", data: { event: "signup" }, options: { queue: "analytics" } },
+]);
 ```
 
 ### Emit options
@@ -156,7 +163,7 @@ const jobId = await hound.emitAsync("property.sync", { propertyId: 1 });
 | `attempts`     | `number`                   | Max retry attempts                                          |
 | `retryDelayMs` | `number`                   | Delay between retries in ms. Default `1000`                 |
 | `retryBackoff` | `'fixed' \| 'exponential'` | Backoff strategy. Default `'fixed'`                         |
-| `repeat`       | `{ pattern: string }`      | Cron expression — makes job self-scheduling                 |
+| `repeat`       | `{ pattern: string; catchUp?: boolean }` | Cron expression — makes job self-scheduling     |
 | `priority`     | `number`                   | Higher = processed first. Default `0`                       |
 
 ---
@@ -177,7 +184,6 @@ hound.on('property.sync', async (ctx) => {
   ctx.emit(...)       // fire and forget from handler
   ctx.emitAsync(...)  // awaitable emit from handler
   ctx.emitAndWait(...)// emit and block until the job completes
-  ctx.socket.update() // WebSocket progress update (requires hound.listen())
 })
 ```
 
@@ -187,7 +193,7 @@ hound.on('property.sync', async (ctx) => {
 | -------------- | -------------------------- | --------------------------------- |
 | `queue`        | `string`                   | Target queue. Default `'default'` |
 | `attempts`     | `number`                   | Max retry attempts                |
-| `repeat`       | `{ pattern: string }`      | Cron expression                   |
+| `repeat`       | `{ pattern: string; catchUp?: boolean }` | Cron expression (`catchUp` defaults to `false`) |
 | `debounce`     | `number`                   | Debounce window in ms             |
 | `retryBackoff` | `'fixed' \| 'exponential'` | Backoff strategy                  |
 
@@ -316,28 +322,6 @@ hound.emit("payment.process", { amount: 100 }, {
 ```ts
 const management = new HoundManagement({ db, hound });
 hound.listen(4000, management);
-```
-
-### WebSocket progress
-
-```ts
-// Handler — send progress updates to connected clients
-hound.on("video.encode", async (ctx) => {
-  await encodeChunk(1);
-  ctx.socket.update({ progress: 33 });
-  await encodeChunk(2);
-  ctx.socket.update({ progress: 66 });
-  await encodeChunk(3);
-  ctx.socket.update({ progress: 100 });
-});
-
-// Client
-const ws = new WebSocket("ws://localhost:4000");
-ws.send(JSON.stringify({ event: "video.encode", data: { id: 1 } }));
-ws.onmessage = ({ data }) => console.log(JSON.parse(data));
-// { type: 'queued', jobId: '...' }
-// { type: 'job_update', progress: 33, ... }
-// { type: 'job_finished', status: 'completed', ... }
 ```
 
 ---

--- a/core/ROADMAP.md
+++ b/core/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-_Last updated: 29/04/2026_
+_Last updated: 01/05/2026_
 
 Use checkboxes. Append `— done DD/MM/YYYY HH:MM` when ticking an item.
 
@@ -27,6 +27,17 @@ Use checkboxes. Append `— done DD/MM/YYYY HH:MM` when ticking an item.
   - Hot-path keyspace isolation during failure spikes
 - [ ] If reintroduced: design as a first-class queue with management API integration, not a config flag.
 
+## v0.51.0 shipped
+
+- [x] `repeat.catchUp` — cron jobs no longer auto-recover on restart/Reaper by default (`catchUp: false`); opt in with `catchUp: true` for financial/compliance crons — _done 29/04/2026_
+- [x] Remove dead `ctx.socket` docs (README + handlers.json) — stub always threw since `expose` was removed in v0.50.0 — _done 01/05/2026_
+
 ## Other
 
-- [ ] 
+- [ ] Remove `ctx.socket` public surface — `JobSocketContext` type, `socket` field on `JobContext`, and the `ctx.socket.update()` stub in `core/libs/hound/mod.ts`. The `expose` option was removed in v0.50.0; the type is now a documentation lie — _added 01/05/2026_
+- [x] `hound.emitBatch(jobs)` — emit multiple jobs atomically in a single Redis pipeline call. The gateway `/emit/batch` endpoint already existed; added `emitBatch()` to the Hound class, updated the gateway to use it, and added `EmitBatchEntry` to public types — _done 01/05/2026_
+- [ ] Pipeline batching for ZADD bursts — when many jobs are emitted in a tight loop, batch them in a single ioredis pipeline instead of individual round trips. Investigate the threshold at which batching yields measurable throughput gains — _added 01/05/2026_
+- [ ] OpenTelemetry middleware — a `hound.use()` middleware (or example plugin) that emits OTEL spans per job (duration, retry count, queue, status) and queue-depth metrics via the management events. Enables off-the-shelf Grafana/Datadog dashboards — _added 01/05/2026_
+- [ ] Per-event rate limiting — `HandlerOptions.rateLimit: { maxPerSecond: number }` to cap handler execution rate without relying on debounce. Useful for outbound API calls with rate limits (Stripe, SendGrid) — _added 01/05/2026_
+- [ ] Node.js / Bun native adapter — Hound currently requires Deno (`Deno.serve`, `Deno.env`, `Deno.Kv`). A thin compatibility package would let teams run the worker in Node or Bun. The generated `HoundClient` already works in any runtime; the gap is the worker side — _added 01/05/2026_
+- [ ] Job progress / streaming — a way to push incremental progress from a running handler to a caller waiting via `emitAndWait`. Needs a design pass: lightweight approach might be periodic state-key writes that the waiter polls; richer approach is a pub/sub channel per job — _added 01/05/2026_

--- a/core/libs/gateways/gateway.ts
+++ b/core/libs/gateways/gateway.ts
@@ -91,6 +91,9 @@ export function createGateway(options: GatewayOptions): Deno.HttpServer<Deno.Net
             options?: EmitOptions;
           }>;
           if (!Array.isArray(jobs)) return json({ error: 'body must be an array' }, 400);
+          for (let i = 0; i < jobs.length; i++) {
+            if (!jobs[i]?.event) return json({ error: `jobs[${i}].event is required` }, 400);
+          }
           const jobIds = await hound.emitBatch(jobs);
           return json({ jobIds });
         }

--- a/core/libs/gateways/gateway.ts
+++ b/core/libs/gateways/gateway.ts
@@ -91,9 +91,7 @@ export function createGateway(options: GatewayOptions): Deno.HttpServer<Deno.Net
             options?: EmitOptions;
           }>;
           if (!Array.isArray(jobs)) return json({ error: 'body must be an array' }, 400);
-          const jobIds = await Promise.all(
-            jobs.map((j) => hound.emitAsync(j.event, j.data, j.options)),
-          );
+          const jobIds = await hound.emitBatch(jobs);
           return json({ jobIds });
         }
 

--- a/core/libs/hound/mod.ts
+++ b/core/libs/hound/mod.ts
@@ -17,6 +17,7 @@ import type {
   EmitAndWaitFunction,
   EmitAsyncFunction,
   EmitBatchEntry,
+  EmitBatchFunction,
   EmitFunction,
   EmitOptions,
   HandlerOptions,
@@ -43,6 +44,8 @@ export type {
   BenchmarkResult,
   EmitAndWaitFunction,
   EmitAsyncFunction,
+  EmitBatchEntry,
+  EmitBatchFunction,
   EmitFunction,
   EmitOptions,
   HandlerOptions,
@@ -66,6 +69,7 @@ export class Hound<
   private readonly ctx: TApp & {
     emit: EmitFunction;
     emitAsync: EmitAsyncFunction;
+    emitBatch: EmitBatchFunction;
   };
   private readonly concurrency: number;
   private readonly processorOptions: HoundOptions<TApp>['processor'];
@@ -133,7 +137,8 @@ export class Hound<
       emit: this.emit.bind(this),
       emitAsync: this.emitAsync.bind(this),
       emitAndWait: this.emitAndWait.bind(this),
-    } as TApp & { emit: EmitFunction; emitAsync: EmitAsyncFunction; emitAndWait: EmitAndWaitFunction };
+      emitBatch: this.emitBatch.bind(this),
+    } as TApp & { emit: EmitFunction; emitAsync: EmitAsyncFunction; emitAndWait: EmitAndWaitFunction; emitBatch: EmitBatchFunction };
 
     this.auth = options.auth;
     this.importMeta = options.importMeta;
@@ -361,31 +366,6 @@ export class Hound<
     return jobId;
   }
 
-  async emitBatch(jobs: EmitBatchEntry[]): Promise<string[]> {
-    if (!jobs.length) return [];
-
-    const payloads = jobs.map(({ event, data, options }) =>
-      this.#buildPayload(event, data, options)
-    );
-
-    const ttl = this.processorOptions?.jobStateTtlSeconds;
-    const pipe = this.db.pipeline();
-
-    for (const [, , stateKey, dataJson] of payloads) {
-      if (typeof ttl === 'number' && ttl > 0) {
-        pipe.set(stateKey, dataJson, 'EX', ttl);
-      } else {
-        pipe.set(stateKey, dataJson);
-      }
-    }
-    for (const [jobId, queue, , , score] of payloads) {
-      pipe.zadd(`queues:${queue}:q`, score, jobId);
-    }
-
-    await pipe.exec();
-    return payloads.map(([jobId]) => jobId);
-  }
-
   #ensureJobWaiterListener(): void {
     if (this.#jobWaiterListenerActive) return;
     this.#jobWaiterListenerActive = true;
@@ -418,6 +398,41 @@ export class Hound<
 
     this.emit(event, data, { ...emitOpts, id: jobId });
     return waitPromise;
+  }
+
+  async emitBatch(jobs: EmitBatchEntry[]): Promise<string[]> {
+    if (!jobs.length) return [];
+
+    const chunkSize = this.processorOptions?.claimCount ?? 200;
+    const ttl = this.processorOptions?.jobStateTtlSeconds;
+    const allIds: string[] = [];
+
+    for (let i = 0; i < jobs.length; i += chunkSize) {
+      const chunk = jobs.slice(i, i + chunkSize);
+      const payloads = chunk.map(({ event, data, options }) =>
+        this.#buildPayload(event, data, options)
+      );
+
+      const tx = this.db.multi();
+      for (const [, , stateKey, dataJson] of payloads) {
+        if (typeof ttl === 'number' && ttl > 0) {
+          tx.set(stateKey, dataJson, 'EX', ttl);
+        } else {
+          tx.set(stateKey, dataJson);
+        }
+      }
+      for (const [jobId, queue, , , score] of payloads) {
+        tx.zadd(`queues:${queue}:q`, score, jobId);
+      }
+
+      const results = await tx.exec() as [Error | null, unknown][];
+      const failed = results.find(([err]) => err !== null);
+      if (failed) throw failed[0]!;
+
+      allIds.push(...payloads.map(([jobId]) => jobId));
+    }
+
+    return allIds;
   }
 
   async benchmark(config: BenchmarkOptions): Promise<BenchmarkResult> {

--- a/core/libs/hound/mod.ts
+++ b/core/libs/hound/mod.ts
@@ -16,6 +16,7 @@ import type {
   BenchmarkResult,
   EmitAndWaitFunction,
   EmitAsyncFunction,
+  EmitBatchEntry,
   EmitFunction,
   EmitOptions,
   HandlerOptions,
@@ -358,6 +359,31 @@ export class Hound<
     await this.queueStore.enqueue(queue, jobId, score);
 
     return jobId;
+  }
+
+  async emitBatch(jobs: EmitBatchEntry[]): Promise<string[]> {
+    if (!jobs.length) return [];
+
+    const payloads = jobs.map(({ event, data, options }) =>
+      this.#buildPayload(event, data, options)
+    );
+
+    const ttl = this.processorOptions?.jobStateTtlSeconds;
+    const pipe = this.db.pipeline();
+
+    for (const [, , stateKey, dataJson] of payloads) {
+      if (typeof ttl === 'number' && ttl > 0) {
+        pipe.set(stateKey, dataJson, 'EX', ttl);
+      } else {
+        pipe.set(stateKey, dataJson);
+      }
+    }
+    for (const [jobId, queue, , , score] of payloads) {
+      pipe.zadd(`queues:${queue}:q`, score, jobId);
+    }
+
+    await pipe.exec();
+    return payloads.map(([jobId]) => jobId);
   }
 
   #ensureJobWaiterListener(): void {

--- a/core/libs/storage/deno-kv.ts
+++ b/core/libs/storage/deno-kv.ts
@@ -236,9 +236,13 @@ export class DenoKvStorage {
     return ['0', [...keys]];
   }
 
-  // ─── Pipeline ──────────────────────────────────────────────────────────────
+  // ─── Pipeline / Multi ──────────────────────────────────────────────────────
 
   pipeline(): DenoKvPipeline {
+    return new DenoKvPipeline(this);
+  }
+
+  multi(): DenoKvPipeline {
     return new DenoKvPipeline(this);
   }
 

--- a/core/libs/storage/in-memory.ts
+++ b/core/libs/storage/in-memory.ts
@@ -205,9 +205,13 @@ export class InMemoryStorage {
     return ['0', [...new Set([...kvKeys, ...zKeys])]];
   }
 
-  // ─── Pipeline ──────────────────────────────────────────────────────────────
+  // ─── Pipeline / Multi ──────────────────────────────────────────────────────
 
   pipeline(): InMemoryPipeline {
+    return new InMemoryPipeline(this);
+  }
+
+  multi(): InMemoryPipeline {
     return new InMemoryPipeline(this);
   }
 

--- a/core/mod.ts
+++ b/core/mod.ts
@@ -60,8 +60,10 @@ export type {
   BenchmarkResult,
   EmitAndWaitFunction,
   EmitAsyncFunction,
-  // Emit function shapes
+  // Emit
   EmitBatchEntry,
+  EmitBatchFunction,
+  // Emit function shapes
   EmitFunction,
   EmitOptions,
   // Handlers

--- a/core/mod.ts
+++ b/core/mod.ts
@@ -61,6 +61,7 @@ export type {
   EmitAndWaitFunction,
   EmitAsyncFunction,
   // Emit function shapes
+  EmitBatchEntry,
   EmitFunction,
   EmitOptions,
   // Handlers

--- a/core/tests/gateway.test.ts
+++ b/core/tests/gateway.test.ts
@@ -16,6 +16,8 @@ function mockHound(opts: { failOn?: string } = {}) {
       if (opts.failOn === event) throw new Error(`forced failure on ${event}`);
       return `job-${++jobSeq}-${event}`;
     },
+    emitBatch: async (jobs: Array<{ event: string }>) =>
+      jobs.map((j) => `job-${++jobSeq}-${j.event}`),
   } as any;
 }
 

--- a/core/tests/hound.test.ts
+++ b/core/tests/hound.test.ts
@@ -327,6 +327,55 @@ Deno.test('ctx.logger appends log entries without throwing', () =>
     await h.emitAndWait('log.test', {}, { timeoutMs: 3000 }); // should not throw
   }));
 
+// ─── emitBatch ───────────────────────────────────────────────────────────────
+
+Deno.test('emitBatch returns one jobId per entry in order', () =>
+  withHound(async (h) => {
+    h.on('batch.a', async () => {});
+    h.on('batch.b', async () => {});
+    const ids = await h.emitBatch([
+      { event: 'batch.a', data: { n: 1 } },
+      { event: 'batch.b', data: { n: 2 } },
+      { event: 'batch.a', data: { n: 3 } },
+    ]);
+    assertEquals(ids.length, 3);
+    assert(ids.every((id) => typeof id === 'string' && id.length > 0));
+  }));
+
+Deno.test('emitBatch returns [] for empty input', () =>
+  withHound(async (h) => {
+    const ids = await h.emitBatch([]);
+    assertEquals(ids, []);
+  }));
+
+Deno.test('emitBatch jobs are all processed', () =>
+  withHound(async (h) => {
+    const N = 10;
+    let count = 0;
+    let resolve!: () => void;
+    const done = new Promise<void>((r) => { resolve = r; });
+
+    h.on('batch.count', async () => {
+      if (++count === N) resolve();
+    });
+    await h.start();
+
+    const ids = await h.emitBatch(
+      Array.from({ length: N }, (_, i) => ({ event: 'batch.count', data: { i } })),
+    );
+    assertEquals(ids.length, N);
+    await done;
+    assertEquals(count, N);
+  }));
+
+Deno.test('emitBatch same payload produces same deterministic id as emitAsync', () =>
+  withHound(async (h) => {
+    h.on('batch.dedup', async () => {});
+    const [batchId] = await h.emitBatch([{ event: 'batch.dedup', data: { x: 42 } }]);
+    const singleId = await h.emitAsync('batch.dedup', { x: 42 });
+    assertEquals(batchId, singleId);
+  }));
+
 // ─── Multiple jobs, correct throughput ───────────────────────────────────────
 
 Deno.test('processes N jobs in parallel up to concurrency limit', () =>

--- a/core/tests/hound.test.ts
+++ b/core/tests/hound.test.ts
@@ -266,6 +266,55 @@ Deno.test('handler can chain follow-up jobs via ctx.emitAsync', () =>
     assertEquals(chainRan, true);
   }));
 
+// ─── emitBatch ───────────────────────────────────────────────────────────────
+
+Deno.test('emitBatch returns one jobId per entry in order', () =>
+  withHound(async (h) => {
+    h.on('batch.a', async () => {});
+    h.on('batch.b', async () => {});
+    const ids = await h.emitBatch([
+      { event: 'batch.a', data: { n: 1 } },
+      { event: 'batch.b', data: { n: 2 } },
+      { event: 'batch.a', data: { n: 3 } },
+    ]);
+    assertEquals(ids.length, 3);
+    assert(ids.every((id) => typeof id === 'string' && id.length > 0));
+  }));
+
+Deno.test('emitBatch returns [] for empty input', () =>
+  withHound(async (h) => {
+    const ids = await h.emitBatch([]);
+    assertEquals(ids, []);
+  }));
+
+Deno.test('emitBatch jobs are all processed', () =>
+  withHound(async (h) => {
+    const N = 10;
+    let count = 0;
+    let resolve!: () => void;
+    const done = new Promise<void>((r) => { resolve = r; });
+
+    h.on('batch.count', async () => {
+      if (++count === N) resolve();
+    });
+    await h.start();
+
+    const ids = await h.emitBatch(
+      Array.from({ length: N }, (_, i) => ({ event: 'batch.count', data: { i } })),
+    );
+    assertEquals(ids.length, N);
+    await done;
+    assertEquals(count, N);
+  }));
+
+Deno.test('emitBatch same payload produces same deterministic ids as individual emitAsync', () =>
+  withHound(async (h) => {
+    h.on('batch.dedup', async () => {});
+    const [batchId] = await h.emitBatch([{ event: 'batch.dedup', data: { x: 42 } }]);
+    const singleId = await h.emitAsync('batch.dedup', { x: 42 });
+    assertEquals(batchId, singleId);
+  }));
+
 // ─── ctx.logger ──────────────────────────────────────────────────────────────
 
 Deno.test('ctx.logger appends log entries without throwing', () =>

--- a/core/types/index.ts
+++ b/core/types/index.ts
@@ -78,6 +78,13 @@ export interface EmitOptions {
   priority?: number;
 }
 
+/** A single entry in an `emitBatch()` call. */
+export interface EmitBatchEntry {
+  event: string;
+  data?: unknown;
+  options?: EmitOptions;
+}
+
 // ─── Handler ─────────────────────────────────────────────────────────────────
 
 /**

--- a/core/types/index.ts
+++ b/core/types/index.ts
@@ -31,6 +31,8 @@ export interface StorageClient {
   ): Promise<[string, string[]]>;
   // deno-lint-ignore no-explicit-any
   pipeline(): any;
+  // deno-lint-ignore no-explicit-any
+  multi(): any;
   disconnect(): void;
 }
 
@@ -120,6 +122,8 @@ export type JobContext<
   emitAsync: EmitAsyncFunction;
   /** Emit and wait for the job to complete. Rejects on failure or timeout. */
   emitAndWait: EmitAndWaitFunction;
+  /** Batch emit — all jobs written in a single MULTI/EXEC transaction. */
+  emitBatch: EmitBatchFunction;
   /** WebSocket context. Only available when hound is started with expose option. */
   socket: JobSocketContext;
 };
@@ -227,6 +231,9 @@ export type EmitAndWaitFunction = (
   data?: unknown,
   options?: EmitOptions & { timeoutMs?: number },
 ) => Promise<string>;
+
+/** Batch emit — writes all jobs in a single MULTI/EXEC transaction. Returns jobIds in order. */
+export type EmitBatchFunction = (jobs: EmitBatchEntry[]) => Promise<string[]>;
 
 /** Options for hound.benchmark(). */
 export interface BenchmarkOptions {

--- a/deno.lock
+++ b/deno.lock
@@ -4,6 +4,7 @@
     "jsr:@deno/esbuild-plugin@^1.2.1": "1.2.1",
     "jsr:@deno/loader@~0.3.10": "0.3.14",
     "jsr:@hushkey/howl@~0.5.1": "0.5.1",
+    "jsr:@std/assert@*": "1.0.19",
     "jsr:@std/bytes@^1.0.6": "1.0.6",
     "jsr:@std/encoding@1": "1.0.10",
     "jsr:@std/encoding@^1.0.10": "1.0.10",
@@ -63,6 +64,12 @@
         "npm:preact",
         "npm:preact-render-to-string",
         "npm:zod"
+      ]
+    },
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
       ]
     },
     "@std/bytes@1.0.6": {

--- a/www/server/docs/emitting-jobs.json
+++ b/www/server/docs/emitting-jobs.json
@@ -9,7 +9,7 @@
       "blocks": [
         {
           "type": "p",
-          "text": "Hound exposes three emission methods depending on how much you need to know about a job's fate:"
+          "text": "Hound exposes four emission methods depending on how much you need to know about a job's fate:"
         },
         {
           "type": "table",
@@ -17,9 +17,10 @@
           "rows": [
             ["emit()", "string (jobId)", "Nothing — fire and forget"],
             ["emitAsync()", "Promise<string>", "Job to be written to storage"],
+            ["emitBatch(jobs)", "Promise<string[]>", "All jobs to be written to storage in a single pipeline"],
             [
               "emitAndWait()",
-              "Promise<JobRecord>",
+              "Promise<string>",
               "Job to reach a terminal state"
             ]
           ]
@@ -57,6 +58,29 @@
           "type": "code",
           "lang": "ts",
           "text": "const jobId = await hound.emitAsync('order.process', { orderId: '123' });\nconsole.log('Job persisted:', jobId);"
+        }
+      ]
+    },
+    {
+      "id": "emit-batch",
+      "heading": "emitBatch()",
+      "blocks": [
+        {
+          "type": "p",
+          "text": "Emit multiple jobs in a single Redis pipeline call. All state key writes and queue ZADDs are batched together — N jobs cost one round trip instead of N:"
+        },
+        {
+          "type": "code",
+          "lang": "ts",
+          "text": "const jobIds = await hound.emitBatch([\n  { event: 'email.send', data: { to: 'alice@example.com' } },\n  { event: 'email.send', data: { to: 'bob@example.com' } },\n  { event: 'analytics.track', data: { event: 'signup' }, options: { queue: 'analytics' } },\n]);\nconsole.log(jobIds); // ['abc...', 'def...', 'ghi...']"
+        },
+        {
+          "type": "tip",
+          "text": "Each entry accepts the same options as emitAsync(). Jobs from different events or queues can be mixed freely in a single batch."
+        },
+        {
+          "type": "p",
+          "text": "emitBatch() is also available on the generated HoundClient for typed, cross-runtime batch emission over the HTTP gateway."
         }
       ]
     },

--- a/www/server/docs/handlers.json
+++ b/www/server/docs/handlers.json
@@ -56,11 +56,6 @@
               "ctx.emitAndWait(...)",
               "Promise<JobRecord>",
               "Emit and await terminal state"
-            ],
-            [
-              "ctx.socket.update(data)",
-              "void",
-              "Push a WebSocket progress update"
             ]
           ]
         }


### PR DESCRIPTION
Emit multiple jobs in one Redis round trip instead of N. All state key                                                                                  
  SETs and queue ZADDs are batched into a single pipeline.                                                                                                
                                                                                                                                                          
  - Add EmitBatchEntry to public types                                                                                                                    
  - Add hound.emitBatch(jobs) to Hound class                                                                                                              
  - Update POST /emit/batch gateway to use hound.emitBatch()                                                                                              
  - Add 4 tests (order, empty input, all processed, deterministic ids)                                                                                    
  - Update emitting-jobs docs and README                                                                                                                  
  - Mark ROADMAP item done       